### PR TITLE
Fix neutral alert race condition

### DIFF
--- a/selfdrive/car/tesla/carcontroller.py
+++ b/selfdrive/car/tesla/carcontroller.py
@@ -26,7 +26,7 @@ class CarController(CarControllerBase):
       self.first_cc_cancel_nanos = now_nanos
     if not CC.cruiseControl.cancel:
       self.first_cc_cancel_nanos = None
-    pcm_cancel_cmd = CC.cruiseControl.cancel and now_nanos - self.first_cc_cancel_nanos > 250000  # 250ms
+    pcm_cancel_cmd = CC.cruiseControl.cancel and now_nanos - self.first_cc_cancel_nanos > 1e9  # 1s
 
     can_sends = []
 


### PR DESCRIPTION
**Description**

This fixes the "Hold up for Neutral" alert that happens sporadically when disengaging with either the brake or lever.

The alert was caused by a race condition between carState and carController, where the following sequence of events would happen:

1. user presses brake pedal or up on gear lever
2. the Tesla DI disengages ACC directly
3. carcontroller gets the cruiseControl.cancel signal, but has old carState with ACC still active
4. carstate is updated for ACC not enabled
5. carcontroller sends pcm cancel command
6. Tesla shows gear alert

I determined that the Tesla self-disengages ACC upon brake or lever up, so it's not normally necessary to send an additional lever-up signal to disengage. Sometimes it's silent because carstate will update before carcontroller gets the cancel signal, and so it avoids the lever-up send.

This fixes the race condition by adding a delay and re-check of the cancel command. It will only send the lever-up signal if a cruise-control cancel was requested and it is not already cancelled within 1 second (this may be reduced a bit, but 250ms was too short and still caused the race condition). In the end, the backup cancellation after 1 second is not necessary, however it's worth leaving as an extra safety layer.

Note that steering override still immediately triggers the cancel signal as that doesn't normally cancel ACC.

**Verification**

Before applying the fix i could reproduce the error about 25% of the time.
After applying the fix I disengaged with the lever, brake, and steering many times, enough to feel certain about the probability.

I also ensured that when canceling with any method, that there was no delay, ensuring that it wasn't falling back on the 1-second cancel delay.

**Route**

Route: bbbf82d987d681bc/000001cb--facd298330